### PR TITLE
Füge Paperless-Button zur Jahresabrechnung hinzu

### DIFF
--- a/librelandlord/bill/admin.py
+++ b/librelandlord/bill/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from django.conf import settings
 # Register your models here.
 
 from . import models
@@ -263,7 +264,7 @@ class BillAdmin(admin.ModelAdmin):
             }),
         ]
         # Paperless-Feld nur anzeigen wenn PAPERLESS_BASE_URL gesetzt ist
-        if os.environ.get('PAPERLESS_BASE_URL'):
+        if settings.PAPERLESS_BASE_URL:
             fieldsets.append(('Paperless', {
                 'fields': ('paperless_id', 'paperless_link', 'paperless_preview'),
                 'classes': ('collapse',)
@@ -271,30 +272,25 @@ class BillAdmin(admin.ModelAdmin):
         return fieldsets
 
     def get_readonly_fields(self, request, obj=None):
-        import os
         readonly = list(super().get_readonly_fields(request, obj))
-        if os.environ.get('PAPERLESS_BASE_URL'):
+        if settings.PAPERLESS_BASE_URL:
             readonly.extend(['paperless_link', 'paperless_preview'])
         return readonly
 
     def paperless_link(self, obj):
         """Zeigt Link zu Paperless-NGX Dokument"""
-        import os
         from django.utils.html import format_html
-        base_url = os.environ.get('PAPERLESS_BASE_URL', '').rstrip('/')
-        if obj.paperless_id and base_url:
-            url = f"{base_url}/documents/{obj.paperless_id}/details"
+        if obj.paperless_id and settings.PAPERLESS_BASE_URL:
+            url = f"{settings.PAPERLESS_BASE_URL}/documents/{obj.paperless_id}/details"
             return format_html('<a href="{}" target="_blank">📄 In Paperless öffnen</a>', url)
         return '-'
     paperless_link.short_description = 'Paperless Link'
 
     def paperless_preview(self, obj):
         """Zeigt Link zur Paperless-NGX PDF Vorschau"""
-        import os
         from django.utils.html import format_html
-        base_url = os.environ.get('PAPERLESS_BASE_URL', '').rstrip('/')
-        if obj.paperless_id and base_url:
-            url = f"{base_url}/api/documents/{obj.paperless_id}/preview/"
+        if obj.paperless_id and settings.PAPERLESS_BASE_URL:
+            url = f"{settings.PAPERLESS_BASE_URL}/api/documents/{obj.paperless_id}/preview/"
             return format_html('<a href="{}" target="_blank">👁️ PDF Vorschau</a>', url)
         return '-'
     paperless_preview.short_description = 'Vorschau'

--- a/librelandlord/bill/context_processors.py
+++ b/librelandlord/bill/context_processors.py
@@ -1,0 +1,8 @@
+from django.conf import settings
+
+
+def paperless_settings(request):
+    """Make Paperless settings available in templates."""
+    return {
+        'PAPERLESS_BASE_URL': settings.PAPERLESS_BASE_URL,
+    }

--- a/librelandlord/bill/templates/bill/includes/bills_table.html
+++ b/librelandlord/bill/templates/bill/includes/bills_table.html
@@ -14,7 +14,23 @@
         <tr>
             <td>{{ bill.bill_date|date:"d.m.Y" }}</td>
             <td class="number-cell">{{ bill.bill_number }}</td>
-            <td>{{ bill.text }}</td>
+            <td>{{ bill.text }}{% if PAPERLESS_BASE_URL %}
+                {% if bill.paperless_id %}
+                <a href="{{ PAPERLESS_BASE_URL }}/documents/{{ bill.paperless_id }}/details"
+                   target="_blank"
+                   class="paperless-btn paperless-btn-linked no-print"
+                   title="In Paperless öffnen (ID: {{ bill.paperless_id }})">
+                    <svg class="paperless-icon" viewBox="43.38 0.14 425.32 512.02"><path d="M136.8 459.6c-2.3-10.8-6.9-32.5-7.4-32.5-96.5-57.7-85.1-157.6-53.1-214.7 6.9 71.9 134.2 121.6 60 209.6-.6 1.1 3.4 14.8 6.9 27.4 14.8-25.1 37.1-55.4 36-58.2-91.4-222.7 194.1-239.8 253.5-378 26.8 133.6-13.7 340.3-243.3 392.9-1.1.6-41.7 71.9-43.4 72.5 0-1.1-17.1-.6-14.8-6.3 1.1-3.6 3.3-8.1 5.6-12.7m56.6-98.8c-36-85.1 69.7-178.7 122.2-202.1C208.2 254.6 189.9 326 193.4 360.8M134 405.9c29.1-33.7-5.1-91.4-25.7-110.2 34.8 60 32.5 94.8 25.7 110.2" transform="translate(-15.306 -14.379)scale(1.10017)"/></svg>
+                </a>
+                {% else %}
+                <button type="button"
+                        class="paperless-btn paperless-btn-unlinked no-print"
+                        onclick="openPaperlessDialog({{ bill.id }}, '{{ bill.text|escapejs }}', '{{ bill.bill_date|date:'d.m.Y' }}', '{{ bill.bill_number|escapejs }}')"
+                        title="Mit Paperless verknüpfen">
+                    <svg class="paperless-icon" viewBox="43.38 0.14 425.32 512.02"><path d="M136.8 459.6c-2.3-10.8-6.9-32.5-7.4-32.5-96.5-57.7-85.1-157.6-53.1-214.7 6.9 71.9 134.2 121.6 60 209.6-.6 1.1 3.4 14.8 6.9 27.4 14.8-25.1 37.1-55.4 36-58.2-91.4-222.7 194.1-239.8 253.5-378 26.8 133.6-13.7 340.3-243.3 392.9-1.1.6-41.7 71.9-43.4 72.5 0-1.1-17.1-.6-14.8-6.3 1.1-3.6 3.3-8.1 5.6-12.7m56.6-98.8c-36-85.1 69.7-178.7 122.2-202.1C208.2 254.6 189.9 326 193.4 360.8M134 405.9c29.1-33.7-5.1-91.4-25.7-110.2 34.8 60 32.5 94.8 25.7 110.2" transform="translate(-15.306 -14.379)scale(1.10017)"/></svg>
+                </button>
+                {% endif %}
+            {% endif %}</td>
             <td>{{ bill.from_date|date:"d.m.Y" }} - {{ bill.to_date|date:"d.m.Y" }}</td>
             <td class="consumption-cell">{{ bill.value|floatformat:2 }} €</td>
         </tr>

--- a/librelandlord/bill/templates/yearly_calculation.html
+++ b/librelandlord/bill/templates/yearly_calculation.html
@@ -549,6 +549,174 @@
                 margin-bottom: 10px;
             }
         }
+
+        /* Paperless Button Styling */
+        .paperless-btn {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            width: 22px;
+            height: 22px;
+            border-radius: 3px;
+            cursor: pointer;
+            text-decoration: none;
+            border: none;
+            padding: 3px;
+            box-sizing: border-box;
+            margin-left: 6px;
+            vertical-align: middle;
+        }
+
+        .paperless-icon {
+            width: 14px;
+            height: 14px;
+        }
+
+        .paperless-btn-linked {
+            background: #e8f5e9;
+        }
+
+        .paperless-btn-linked .paperless-icon path {
+            fill: #17541f;
+        }
+
+        .paperless-btn-linked:hover {
+            background: #c8e6c9;
+        }
+
+        .paperless-btn-unlinked {
+            background: #f5f5f5;
+        }
+
+        .paperless-btn-unlinked .paperless-icon path {
+            fill: #9e9e9e;
+        }
+
+        .paperless-btn-unlinked:hover {
+            background: #e0e0e0;
+        }
+
+        .paperless-btn-unlinked:hover .paperless-icon path {
+            fill: #616161;
+        }
+
+        /* Paperless Dialog */
+        .paperless-dialog-overlay {
+            display: none;
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: rgba(0, 0, 0, 0.5);
+            z-index: 1000;
+            justify-content: center;
+            align-items: center;
+        }
+
+        .paperless-dialog-overlay.active {
+            display: flex;
+        }
+
+        .paperless-dialog {
+            background: white;
+            border-radius: 8px;
+            padding: 20px;
+            max-width: 400px;
+            width: 90%;
+            box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+        }
+
+        .paperless-dialog h3 {
+            margin: 0 0 10px 0;
+            color: #333;
+        }
+
+        .paperless-dialog p {
+            margin: 0 0 15px 0;
+            color: #666;
+            font-size: 0.9em;
+        }
+
+        .paperless-dialog input {
+            width: 100%;
+            padding: 10px;
+            font-size: 16px;
+            border: 2px solid #ddd;
+            border-radius: 4px;
+            margin-bottom: 15px;
+            box-sizing: border-box;
+        }
+
+        .paperless-dialog input:focus {
+            border-color: #2196f3;
+            outline: none;
+        }
+
+        .paperless-dialog-buttons {
+            display: flex;
+            gap: 10px;
+            justify-content: flex-end;
+        }
+
+        .paperless-dialog-buttons button {
+            padding: 8px 16px;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 14px;
+            border: none;
+        }
+
+        .paperless-dialog-buttons .btn-cancel {
+            background: #f5f5f5;
+            color: #333;
+        }
+
+        .paperless-dialog-buttons .btn-cancel:hover {
+            background: #e0e0e0;
+        }
+
+        .paperless-dialog-buttons .btn-save {
+            background: #4caf50;
+            color: white;
+        }
+
+        .paperless-dialog-buttons .btn-save:hover {
+            background: #43a047;
+        }
+
+        .paperless-dialog .error-message {
+            color: #f44336;
+            font-size: 0.85em;
+            margin-top: -10px;
+            margin-bottom: 10px;
+            display: none;
+        }
+
+        .paperless-search-links {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            align-items: center;
+            margin-bottom: 15px;
+            font-size: 0.9em;
+        }
+
+        .paperless-search-links span {
+            color: #666;
+        }
+
+        .paperless-search-links a {
+            background: #e3f2fd;
+            color: #1976d2;
+            padding: 4px 10px;
+            border-radius: 4px;
+            text-decoration: none;
+        }
+
+        .paperless-search-links a:hover {
+            background: #bbdefb;
+        }
     </style>
 </head>
 
@@ -957,6 +1125,133 @@
         </div>
     </div>
     {% endfor %}
+    {% endif %}
+
+    {% if PAPERLESS_BASE_URL %}
+    <!-- Paperless Dialog -->
+    <div class="paperless-dialog-overlay no-print" id="paperlessDialogOverlay">
+        <div class="paperless-dialog">
+            <h3>Paperless-ID verknüpfen</h3>
+            <p id="paperlessDialogBillText"></p>
+            <div class="paperless-search-links">
+                <span>In Paperless suchen:</span>
+                <a href="#" id="paperlessSearchDate" target="_blank"></a>
+                <a href="#" id="paperlessSearchNumber" target="_blank"></a>
+            </div>
+            <input type="number" id="paperlessIdInput" placeholder="Dokument-ID aus Paperless" min="1">
+            <div class="error-message" id="paperlessErrorMessage"></div>
+            <div class="paperless-dialog-buttons">
+                <button type="button" class="btn-cancel" onclick="closePaperlessDialog()">Abbrechen</button>
+                <button type="button" class="btn-save" onclick="savePaperlessId()">Speichern</button>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        let currentBillId = null;
+        const paperlessBaseUrl = '{{ PAPERLESS_BASE_URL }}';
+
+        function openPaperlessDialog(billId, billText, billDate, billNumber) {
+            currentBillId = billId;
+            document.getElementById('paperlessDialogBillText').textContent = billText;
+
+            // Suchlinks setzen
+            const searchDateLink = document.getElementById('paperlessSearchDate');
+            searchDateLink.href = paperlessBaseUrl + '/documents?title_content=' + encodeURIComponent(billDate);
+            searchDateLink.textContent = billDate;
+
+            const searchNumberLink = document.getElementById('paperlessSearchNumber');
+            searchNumberLink.href = paperlessBaseUrl + '/documents?title_content=' + encodeURIComponent(billNumber);
+            searchNumberLink.textContent = billNumber;
+
+            document.getElementById('paperlessIdInput').value = '';
+            document.getElementById('paperlessErrorMessage').style.display = 'none';
+            document.getElementById('paperlessDialogOverlay').classList.add('active');
+            document.getElementById('paperlessIdInput').focus();
+        }
+
+        function closePaperlessDialog() {
+            document.getElementById('paperlessDialogOverlay').classList.remove('active');
+            currentBillId = null;
+        }
+
+        function savePaperlessId() {
+            const paperlessId = document.getElementById('paperlessIdInput').value.trim();
+            const errorEl = document.getElementById('paperlessErrorMessage');
+
+            if (!paperlessId) {
+                errorEl.textContent = 'Bitte eine Paperless-ID eingeben';
+                errorEl.style.display = 'block';
+                return;
+            }
+
+            if (isNaN(parseInt(paperlessId)) || parseInt(paperlessId) < 1) {
+                errorEl.textContent = 'Bitte eine gültige positive Zahl eingeben';
+                errorEl.style.display = 'block';
+                return;
+            }
+
+            // CSRF Token holen
+            const csrfToken = document.querySelector('[name=csrfmiddlewaretoken]')?.value ||
+                             getCookie('csrftoken');
+
+            fetch(`/bill/api/bill/${currentBillId}/paperless-id/`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                    'X-CSRFToken': csrfToken
+                },
+                body: `paperless_id=${encodeURIComponent(paperlessId)}`
+            })
+            .then(response => response.json())
+            .then(data => {
+                if (data.success) {
+                    // Seite neu laden um den aktualisierten Button anzuzeigen
+                    location.reload();
+                } else {
+                    errorEl.textContent = data.error || 'Fehler beim Speichern';
+                    errorEl.style.display = 'block';
+                }
+            })
+            .catch(error => {
+                errorEl.textContent = 'Netzwerkfehler: ' + error.message;
+                errorEl.style.display = 'block';
+            });
+        }
+
+        function getCookie(name) {
+            let cookieValue = null;
+            if (document.cookie && document.cookie !== '') {
+                const cookies = document.cookie.split(';');
+                for (let i = 0; i < cookies.length; i++) {
+                    const cookie = cookies[i].trim();
+                    if (cookie.substring(0, name.length + 1) === (name + '=')) {
+                        cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+                        break;
+                    }
+                }
+            }
+            return cookieValue;
+        }
+
+        // Dialog schließen bei Klick außerhalb
+        document.getElementById('paperlessDialogOverlay').addEventListener('click', function(e) {
+            if (e.target === this) {
+                closePaperlessDialog();
+            }
+        });
+
+        // Dialog schließen bei Escape-Taste
+        document.addEventListener('keydown', function(e) {
+            if (e.key === 'Escape') {
+                closePaperlessDialog();
+            }
+            // Enter-Taste zum Speichern
+            if (e.key === 'Enter' && document.getElementById('paperlessDialogOverlay').classList.contains('active')) {
+                savePaperlessId();
+            }
+        });
+    </script>
     {% endif %}
 </body>
 

--- a/librelandlord/bill/urls.py
+++ b/librelandlord/bill/urls.py
@@ -39,4 +39,7 @@ urlpatterns = [
     # API für Dashboard-Statistiken
     path("api/dashboard-stats/", views.dashboard_stats_api,
          name="dashboard_stats_api"),
+    # API für Paperless-ID Update
+    path("api/bill/<int:bill_id>/paperless-id/", views.bill_paperless_id_update,
+         name="bill_paperless_id_update"),
 ]

--- a/librelandlord/librelandlord/settings.py
+++ b/librelandlord/librelandlord/settings.py
@@ -47,6 +47,10 @@ USE_OIDC_ONLY = os.environ.get('USE_OIDC_ONLY', 'False').lower() == 'true'
 
 HEATING_INFO_FOOTER = "Für Fragen oder wenn Daten nicht plausibel sind, wenden Sie sich bitte an Ihren Vermieter: Sven Anders, Neehusenstaße 11a, 21147 Hamburg, 040-2004297"
 
+# Paperless-NGX Integration
+# URL to Paperless-NGX instance (without trailing slash), e.g. https://paperless.example.com
+PAPERLESS_BASE_URL = os.environ.get('PAPERLESS_BASE_URL', '').rstrip('/')
+
 # Application definition
 
 INSTALLED_APPS = [
@@ -90,6 +94,7 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+                'bill.context_processors.paperless_settings',
             ],
         },
     },


### PR DESCRIPTION
- Paperless-NGX Icon hinter Rechnungstext in yearly-calculation
- Dialog zum Verknüpfen mit Paperless-Dokumenten
- Suchlinks nach Rechnungsdatum und -nummer im Dialog
- API-Endpunkt zum Speichern der Paperless-ID
- PAPERLESS_BASE_URL zentral in settings.py definiert
- Button wird im Druck ausgeblendet