### PR TITLE
Füge django-compressor für CSS/JS Minifizierung hinzu

### DIFF
--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -86,8 +86,9 @@ RUN chown -R app:app /app
 # Zu non-root user wechseln
 USER app
 
-# Statische Dateien sammeln
-RUN python manage.py collectstatic --noinput
+# Statische Dateien sammeln und komprimieren
+RUN python manage.py collectstatic --noinput && \
+    python manage.py compress --force
 
 # Port freigeben
 EXPOSE 8000

--- a/librelandlord/bill/templates/admin/base_site.html
+++ b/librelandlord/bill/templates/admin/base_site.html
@@ -1,10 +1,14 @@
 {% extends "admin/base_site.html" %}
-{% load i18n static %}
+{% load i18n static compress %}
 
 {% block extrahead %}
 {{ block.super }}
+{% compress css %}
 <link rel="stylesheet" href="{% static 'bill/css/admin/admin-dashboard.css' %}">
+{% endcompress %}
+{% compress js %}
 <script src="{% static 'bill/js/admin/admin-dashboard.js' %}"></script>
+{% endcompress %}
 {% endblock %}
 
 {% block branding %}

--- a/librelandlord/bill/templates/heating_info.html
+++ b/librelandlord/bill/templates/heating_info.html
@@ -1,10 +1,12 @@
 {% load i18n %}
 {% load l10n %}
+{% load compress %}
 {% get_current_language as current_language %}
 <!DOCTYPE html>
 <html lang="{{ current_language }}">
     <head>
         <meta charset="utf-8">
+        {% compress css %}
         <style>
 @page {
 		size: A4 landscape;
@@ -108,6 +110,7 @@ tr:nth-child(odd) .percentage {
     }
 }
         </style>
+        {% endcompress %}
     </head>
     <body>
         <h1>{% trans 'Your Monthly Consumption Statistics' %}</h1>

--- a/librelandlord/bill/templates/meter_readings_input.html
+++ b/librelandlord/bill/templates/meter_readings_input.html
@@ -1,4 +1,6 @@
 {% load l10n %}
+{% load static %}
+{% load compress %}
 <!DOCTYPE html>
 <html lang="de">
 
@@ -6,8 +8,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Zählerstände eingeben - {{ target_date }}</title>
-    <!-- CSS Dateien -->
-    {% load static %}
+    {% compress css %}
     <link rel="stylesheet" href="{% static 'bill/css/all.min.css' %}">
     <link rel="stylesheet" href="{% static 'bill/css/meter-readings.css' %}">
     <style>
@@ -24,7 +25,7 @@
             }
         }
     </style>
-
+    {% endcompress %}
 </head>
 
 <body>
@@ -161,7 +162,9 @@
         Zählerstände vom {{ target_date|date:"d.m.Y" }} - Gedruckt am {% now "d.m.Y H:i" %}
     </div>
 
+    {% compress js %}
     <script src="{% static 'bill/js/meter-readings.js' %}"></script>
+    {% endcompress %}
 </body>
 
 </html>

--- a/librelandlord/bill/templates/tax_overview.html
+++ b/librelandlord/bill/templates/tax_overview.html
@@ -1,4 +1,5 @@
 {% load static %}
+{% load compress %}
 <!DOCTYPE html>
 <html lang="de">
 
@@ -6,10 +7,11 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Steuerübersicht {{ billing_year }}</title>
-    <!-- CSS Dateien -->
+    {% compress css %}
     <link rel="stylesheet" href="{% static 'bill/css/base.css' %}">
     <link rel="stylesheet" href="{% static 'bill/css/print-base.css' %}">
     <link rel="stylesheet" href="{% static 'bill/css/tax-overview.css' %}">
+    {% endcompress %}
 </head>
 
 <body>

--- a/librelandlord/bill/templates/yearly_calculation.html
+++ b/librelandlord/bill/templates/yearly_calculation.html
@@ -1,5 +1,6 @@
 {% load markdown_extras %}
 {% load static %}
+{% load compress %}
 <!DOCTYPE html>
 <html lang="de">
 
@@ -7,11 +8,12 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Jahresabrechnung {{ billing_year }}</title>
-    <!-- CSS Dateien -->
+    {% compress css %}
     <link rel="stylesheet" href="{% static 'bill/css/base.css' %}">
     <link rel="stylesheet" href="{% static 'bill/css/print-base.css' %}">
     <link rel="stylesheet" href="{% static 'bill/css/yearly-calculation.css' %}">
     <link rel="stylesheet" href="{% static 'bill/css/components/paperless-dialog.css' %}">
+    {% endcompress %}
 </head>
 
 <body>
@@ -495,7 +497,9 @@
             </div>
         </div>
     </div>
+    {% compress js %}
     <script src="{% static 'bill/js/components/paperless-dialog.js' %}"></script>
+    {% endcompress %}
     {% endif %}
 </body>
 

--- a/librelandlord/librelandlord/settings.py
+++ b/librelandlord/librelandlord/settings.py
@@ -62,6 +62,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'mozilla_django_oidc',
+    'compressor',
 ]
 
 MIDDLEWARE = [
@@ -189,6 +190,24 @@ STATIC_ROOT = BASE_DIR / 'staticfiles'
 
 # WhiteNoise configuration for serving static files in production
 STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
+
+# Static files finders
+STATICFILES_FINDERS = [
+    'django.contrib.staticfiles.finders.FileSystemFinder',
+    'django.contrib.staticfiles.finders.AppDirectoriesFinder',
+    'compressor.finders.CompressorFinder',
+]
+
+# Django Compressor settings
+COMPRESS_ENABLED = not DEBUG  # Only compress in production
+COMPRESS_OFFLINE = not DEBUG  # Pre-compress during deployment
+COMPRESS_CSS_FILTERS = [
+    'compressor.filters.css_default.CssAbsoluteFilter',
+    'compressor.filters.cssmin.rCSSMinFilter',
+]
+COMPRESS_JS_FILTERS = [
+    'compressor.filters.jsmin.rJSMinFilter',
+]
 
 # Force Django to serve static files even in production for small systems
 # This is not recommended for high-traffic sites, but acceptable for small systems

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Django==5.2.9
+django-compressor==4.5.1
 django-weasyprint==2.3.0
 markdown==3.7
 mozilla-django-oidc==4.0.1


### PR DESCRIPTION
- django-compressor 4.5.1 zu requirements.txt hinzugefügt
- Compressor-Konfiguration in settings.py (nur in Production aktiv)
- Templates angepasst mit {% compress %} Tags:
  - yearly_calculation.html
  - tax_overview.html
  - admin/base_site.html
  - meter_readings_input.html
  - heating_info.html

In Production: `python manage.py compress` beim Deployment ausführen.