### PR TITLE
Fix PDF-Generierung: CSS-Loading und Übersetzungen

### DIFF
--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -48,7 +48,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     default-libmysqlclient-dev \
     default-mysql-client \
     mariadb-client-compat \
-    pkg-config
+    pkg-config \
+    gettext
 
 # Requirements kopieren und installieren (vor App-Code für besseres Caching)
 COPY requirements.txt .
@@ -86,8 +87,9 @@ RUN chown -R app:app /app
 # Zu non-root user wechseln
 USER app
 
-# Statische Dateien sammeln und komprimieren
-RUN python manage.py collectstatic --noinput && \
+# Übersetzungen kompilieren, statische Dateien sammeln und komprimieren
+RUN python manage.py compilemessages && \
+    python manage.py collectstatic --noinput && \
     python manage.py compress --force
 
 # Port freigeben

--- a/librelandlord/bill/views/heating_info.py
+++ b/librelandlord/bill/views/heating_info.py
@@ -9,6 +9,7 @@ import decimal
 import json
 
 from weasyprint import HTML
+from django_weasyprint.utils import django_url_fetcher
 
 from ..models import Renter, HeatingInfo, HeatingInfoTemplate, Landlord
 
@@ -194,7 +195,9 @@ def heating_info_pdf(request, id: int):
     html = template.render(context, request)
 
     # Generiere das PDF mit WeasyPrint
-    pdf = HTML(string=html).write_pdf()
+    # base_url und url_fetcher ermöglichen das Laden von statischen Dateien
+    base_url = request.build_absolute_uri('/')
+    pdf = HTML(string=html, base_url=base_url, url_fetcher=django_url_fetcher).write_pdf()
 
     response = HttpResponse(pdf, content_type='application/pdf')
     response['Content-Disposition'] = 'inline; filename="heating_info.pdf"'
@@ -512,7 +515,9 @@ def heating_info_pdf_by_token(request, token: str):
     html = template.render(context, request)
 
     # Generiere das PDF mit WeasyPrint
-    pdf = HTML(string=html).write_pdf()
+    # base_url und url_fetcher ermöglichen das Laden von statischen Dateien
+    base_url = request.build_absolute_uri('/')
+    pdf = HTML(string=html, base_url=base_url, url_fetcher=django_url_fetcher).write_pdf()
 
     response = HttpResponse(pdf, content_type='application/pdf')
     response['Content-Disposition'] = 'inline; filename="heating_info.pdf"'

--- a/librelandlord/librelandlord/settings.py
+++ b/librelandlord/librelandlord/settings.py
@@ -69,11 +69,11 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
-    'django.middleware.locale.LocaleMiddleware',
     'django.middleware.security.SecurityMiddleware',
     # Add this for static files in production
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.locale.LocaleMiddleware',  # Must be after SessionMiddleware
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -171,7 +171,7 @@ AUTH_PASSWORD_VALIDATORS = [
 # Internationalization
 # https://docs.djangoproject.com/en/5.0/topics/i18n/
 
-LANGUAGE_CODE = 'de'
+LANGUAGE_CODE = os.environ.get('LANGUAGE_CODE', 'de')
 
 TIME_ZONE = 'UTC'
 


### PR DESCRIPTION
- WeasyPrint mit django_url_fetcher für korrektes CSS-Loading in Produktion
- LocaleMiddleware nach SessionMiddleware verschoben (Django Best Practice)
- LANGUAGE_CODE per ENV konfigurierbar
- Dockerfile: gettext und compilemessages hinzugefügt