### PR TITLE
Emoji-Font für PDF-Generierung hinzugefügt

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,12 @@ Distribution types (in CostCenter):
 - Language: German for domain terms and user-facing content, English for code structure
 - All text uses LF line endings with final newline
 
+## Git Branch Naming
+
+Branch names follow the pattern: `YYYY-MM-DD_short_description`
+
+Example: `2026-02-02_fix_emoji_pdf_font`
+
 ## Environment Configuration
 
 Key environment variables (see `.env.example` and `.env.production`):

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -49,7 +49,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     default-mysql-client \
     mariadb-client-compat \
     pkg-config \
-    gettext
+    gettext \
+    fonts-noto-color-emoji
 
 # Requirements kopieren und installieren (vor App-Code für besseres Caching)
 COPY requirements.txt .


### PR DESCRIPTION
## Summary
- fonts-noto-color-emoji im Dockerfile installiert
- WeasyPrint kann nun Emojis in PDFs korrekt darstellen (Heating Info PDF)
- Branch-Namenskonvention in CLAUDE.md dokumentiert

## Test plan
- [ ] Docker-Image neu bauen
- [ ] Heating Info PDF generieren und Emojis prüfen

🤖 Generated with [Claude Code](https://claude.com/claude-code)